### PR TITLE
Use latest substrait & bump crate version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "glob",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "substrait"
 description = "Rust bindings for Substrait"
-version = "0.1.0"
+version = "0.2.0"
 repository = "https://github.com/substrait/substrait-rs"
 homepage = "https://github.com/substrait/substrait-rs"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod tests {
         let _ = Literal {
             nullable: true,
             literal_type: Some(LiteralType::I32(123)),
+            type_variation_reference: 0,
         };
     }
 }


### PR DESCRIPTION
It turns out that I had already published a 0.1.0 version to crates.io some time ago (https://crates.io/crates/substrait/0.1.0)

This PR bumps the version to 0.2.0 and updates the substrait submodule to pick up the latest .proto files. Once this is merged I will publish the new version.