### PR TITLE
Add repo-token to setup-protoc action to avoid rate limiting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,8 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: check
@@ -31,6 +33,8 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: test
@@ -63,6 +67,8 @@ jobs:
           toolchain: stable
           components: clippy
       - uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: clippy


### PR DESCRIPTION
This should prevent:
```
Error: API rate limit exceeded for x.x.x.x. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```