### PR TITLE
Change schedule time for Dependabot submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      # 1 hour after the weekly Substrait release
+      # 4 hours after the weekly Substrait release cron job
       # https://github.com/substrait-io/substrait/blob/90fce6a582c1009435d26b63083486ac1eed5906/.github/workflows/release.yml#L1-L6
       interval: "weekly"
       day: "sunday"
-      time: "03:00"
+      time: "06:00"


### PR DESCRIPTION
It seems that with the current configuration we missed the release (https://github.com/substrait-io/substrait-rs/pull/13). It seems the release cron job of Substrait typically gets scheduled with a delay, so this PR changes the schedule to trigger 4 hours after the specified release cron job of Substrait.