### PR TITLE
Disable auto rebase for cargo dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
With bors enabled on this repo now, this PR disables the auto rebase strategy for Cargo update PRs. When bors is trying a batch it will cancel it when one of the branches in that PR is pushed (e.g. when dependabot force pushes a rebase) e.g. https://github.com/substrait-io/substrait-rs/pull/19. The other updates are less likely to trigger a rebase (for Cargo it's typically the lock file).