### PR TITLE
chore(ci): also check on macos and windows

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -10,7 +10,6 @@ status = [
   "Check (ubuntu-latest, serde)",
   "Check (windows-latest, default)",
   "Check (windows-latest, pbjson)",
-  "Check (windows-latest, protoc)",
   "Check (windows-latest, serde)",
   "Clippy (default)",
   "Clippy (pbjson)",

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,9 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 status = [
-  "Check (default)",
-  "Check (pbjson)",
-  "Check (protoc)",
-  "Check (serde)",
+  "Check (macos-latest, default)",
+  "Check (macos-latest, pbjson)",
+  "Check (macos-latest, protoc)",
+  "Check (macos-latest, serde)",
+  "Check (ubuntu-latest, default)",
+  "Check (ubuntu-latest, pbjson)",
+  "Check (ubuntu-latest, protoc)",
+  "Check (ubuntu-latest, serde)",
+  "Check (windows-latest, default)",
+  "Check (windows-latest, pbjson)",
+  "Check (windows-latest, protoc)",
+  "Check (windows-latest, serde)",
   "Clippy (default)",
   "Clippy (pbjson)",
   "Clippy (serde)",
@@ -14,7 +22,7 @@ status = [
   "SPDX License Header",
   "Test (default)",
   "Test (pbjson)",
-  "Test (serde)",
+  "Test (serde)"
 ]
 delete-merged-branches = true
 timeout-sec = 600

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           - pbjson
           - protoc
           - serde
+        exclude:
+          - os: windows-latest
+            feature: protoc
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,14 @@ on: [push, pull_request]
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
         feature:
           - default
           - pbjson


### PR DESCRIPTION
Trying to reproduce #53 in CI and prevent future regressions on other platforms.
Skipping the `protoc` feature on Windows because that is not supported yet (https://github.com/MaterializeInc/rust-protobuf-native/issues/4).