### PR TITLE
[Merged by Bors] - chore(ci): also check PR body for conventional commits

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.ref == 'refs/heads/staging'
-        uses: actions/checkout@v3
-      - if: github.ref == 'refs/heads/staging'
         uses: actions/setup-node@v3
       - if: github.ref == 'refs/heads/staging'
-        run: |
-          npm install @commitlint/config-conventional
-          echo "${{ github.event.head_commit.message }}" | npx commitlint --extends @commitlint/config-conventional
+        run: npm install @commitlint/config-conventional
+      - if: github.ref == 'refs/heads/staging'
+        run: npx commitlint --extends @commitlint/config-conventional <<< $CONVENTIONAL_COMMIT
+        env:
+          CONVENTIONAL_COMMIT: ${{ github.event.head_commit.message }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,48 +10,23 @@ on:
       - edited
       - synchronize
 
-permissions:
-  issues: write
-
 jobs:
-  title:
-    name: Title
+  conventional-commits:
+    name: Conventional Commits
     runs-on: ubuntu-latest
     if: "!startsWith(github.event.pull_request.title, '[Merged by Bors] - ')"
     steps:
       - uses: actions/setup-node@v3
       - run: npm install @commitlint/config-conventional
-      - id: commitlint
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint --extends @commitlint/config-conventional
+      - run: npx commitlint --extends @commitlint/config-conventional <<< $CONVENTIONAL_COMMIT
+        env:
+          CONVENTIONAL_COMMIT: |
+            ${{ github.event.pull_request.title }}
+
+            ${{ github.event.pull_request.body }}
       - if: failure()
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const message = `Substrait follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for release automation.
-              The PR title is used as the merge commit message.
-              
-              Please update your PR title to match the specification.`
+        run:
+          echo "Substrait follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for release automation.
+          The PR title and body are used as the merge commit message.
 
-            // Get list of current comments
-            const list_comments = github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            })
-            const comments = await github.paginate(list_comments)
-
-            // Check if this job already commented
-            for (const comment of comments) {
-              if (comment.body === message) {
-                return // Already commented
-              }
-            }
-
-            // Post the comment about Conventional Commits
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: message
-            })
-            core.setFailed('Invalid PR title')
+          Please update your PR title to match the specification." >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,13 @@ All contributors and contributions are welcome! Please open an issue on GitHub i
 
 ### Pull requests
 
-Substrait follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for Pull Request titles. This allows for automation of releases based on commit messages that are merged to the default branch.
+Substrait follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages. This allows for automation of releases based on commit messages that are merged to the default branch.
 
-The `Title` job of the [Pull Request](.github/workflow/pull-request.yml) workflow and the `Conventional Commits` job of the [Merge](.github/workflows/merge.yml) workflow check the Pull Request title and merge commit message.
+The `Conventional Commits` job of the [Pull Request](.github/workflows/pull-request.yml) workflow and the `Conventional Commits` job of the [Merge](.github/workflows/merge.yml) workflow check the Pull Request title and body and the resulting merge commit message.
+
+### Releases
+
+Releases are published automatically with the [Release](./github/workflows/release.yml) workflow. The workflow is triggered for every commit to the `main` branch. [`cargo-smart-release`](https://github.com/Byron/gitoxide/tree/main/cargo-smart-release) is used to bump the version, create and publish the new release.
 
 ### Dependabot
 


### PR DESCRIPTION
Following the main Substrait repository: this makes the PR check match the Merge
check by also checking the body of the PR.  

The PR comment note is moved to the job summary.

Added a note about the use of
[`cargo-smart-release`](https://github.com/Byron/gitoxide/tree/main/cargo-smart-release)
to the contributing guide.

Closes #55. Closes #43.
