### PR TITLE
[Merged by Bors] - chore(deps,cargo)!: bump `prost-wkt` dependencies to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ pbjson = { version = "0.5", optional = true }
 pbjson-types = { version = "0.5", optional = true }
 prost = "0.11"
 prost-types = "0.11"
-prost-wkt = { version = "0.3", optional = true }
-prost-wkt-types = { version = "0.3", optional = true }
+prost-wkt = { version = "0.4", optional = true }
+prost-wkt-types = { version = "0.4", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
@@ -44,7 +44,7 @@ heck = "0.4"
 pbjson-build = { version = "0.5", optional = true }
 prost-build = { version = "0.11", default-features = false }
 prost-types = "0.11"
-prost-wkt-build = { version = "0.3", optional = true }
+prost-wkt-build = { version = "0.4", optional = true }
 protobuf-src = { version = "1", optional = true }
 schemars = "0.8"
 serde_yaml = "0.9"


### PR DESCRIPTION
Closes #50
Closes #51 
Closes #52

These have to be combined to pass CI.

This is a breaking change because the deprecated `encoded` method from the
`MessageSerde` trait was removed.