### PR TITLE
[Merged by Bors] - chore: ignore dtolnay/rust-toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "chore(deps,github-actions)"
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"


### PR DESCRIPTION
The way that action works is not really compatible with how dependabot suggests
updates (e.g. https://github.com/substrait-io/substrait-rs/pull/67) for it so
this modifies the configuration to ignore those "updates".