### PR TITLE
[Merged by Bors] - chore(ci): update crates index when creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
           cargo smart-release \
+            --update-crates-index \
             --allow-fully-generated-changelogs \
             --execute \
             --no-changelog-preview \


### PR DESCRIPTION
As suggested by a failed run:
```console
[WARN ] Consider running with --update-crates-index to assure bumping on demand
uses the latest information
```
This adds `--update-crates-index` to the smart-release invocation.