### PR TITLE
[Merged by Bors] - chore: replace removed `typfify::TypeSpace::to_string()` with `prettyplease`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,14 @@ serde_json = "1"
 [build-dependencies]
 heck = "0.4"
 pbjson-build = { version = "0.5", optional = true }
+prettyplease = "0.1.25"
 prost-build = { version = "0.11", default-features = false }
 prost-types = "0.11"
 prost-wkt-build = { version = "0.4", optional = true }
 protobuf-src = { version = "1", optional = true }
 schemars = "0.8"
 serde_yaml = "0.9"
+syn = "1.0.109"
 typify = "0.0.10"
 walkdir = "2"
 

--- a/build.rs
+++ b/build.rs
@@ -71,7 +71,7 @@ pub mod {title} {{
     use serde::{{Deserialize, Serialize}};
     {}
 }}"#,
-            type_space.to_string()
+            prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream())?),
         ))?;
     }
     Ok(())


### PR DESCRIPTION
The use of `typify` assumed that `rustfmt` was installed... which turned out not to be a great assumption. We've modified `typify` to remove the dependency on `rustfmt-wrapper` and have removed the interface that used it `ToString::to_string()`. Instead we recommend that consumers use `prettyplease` for `build.rs` uses such as the one in this crate. See https://github.com/oxidecomputer/typify/pull/221

Alternatively, the `build.rs` could just emit the tokens unformatted (to remove the build-time dependency on `prettyplease` and `syn`), but that seems annoying if and when you need to look at the generated code.

FWIW `syn` is an existing dependency; `prettyplease` is the only new new crate I see in `Cargo.lock`.

I can share the full diff between the old and new versions of the `substrait_text.rs`, but here's a sample:

```diff
@@ -1593,22 +1831,27 @@
             T: std::convert::TryInto<Option<super::SessionDependent>>,
             T::Error: std::fmt::Display,
         {
-            self.session_dependent = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for session_dependent: {}",
-                    e
-                )
-            });
             self
+                .session_dependent = value
+                .try_into()
+                .map_err(|e| {
+                    format!(
+                        "error converting supplied value for session_dependent: {}", e
+                    )
+                });
+            self
         }
         pub fn variadic<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<Option<super::VariadicBehavior>>,
             T::Error: std::fmt::Display,
         {
-            self.variadic = value
+            self
+                .variadic = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for variadic: {}", e));
+                .map_err(|e| {
+                    format!("error converting supplied value for variadic: {}", e)
+                });
             self
         }
         pub fn window_type<T>(mut self, value: T) -> Self
```