### PR TITLE
[Merged by Bors] - chore: add commitlint config file to disable max line length limits

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.ref == 'refs/heads/staging'
+        uses: actions/checkout@v3
+      - if: github.ref == 'refs/heads/staging'
         uses: actions/setup-node@v3
       - if: github.ref == 'refs/heads/staging'
         run: npm install @commitlint/config-conventional

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,6 +18,6 @@ jobs:
       - if: github.ref == 'refs/heads/staging'
         run: npm install @commitlint/config-conventional
       - if: github.ref == 'refs/heads/staging'
-        run: npx commitlint --extends @commitlint/config-conventional <<< $CONVENTIONAL_COMMIT
+        run: npx commitlint <<< $CONVENTIONAL_COMMIT
         env:
           CONVENTIONAL_COMMIT: ${{ github.event.head_commit.message }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
       - run: npm install @commitlint/config-conventional
-      - run: npx commitlint --extends @commitlint/config-conventional <<< $CONVENTIONAL_COMMIT
+      - run: npx commitlint <<< $CONVENTIONAL_COMMIT
         env:
           CONVENTIONAL_COMMIT: |
             ${{ github.event.pull_request.title }}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0, "always", Infinity],
+    "footer-max-line-length": [0, "always", Infinity],
+    "header-max-length": [0, "always", Infinity],
+  },
+};


### PR DESCRIPTION
Adds a [commitlint configuration file](https://commitlint.js.org/#/reference-configuration) that "disables" the max (line) length rules. These limits are not required by the conventional commits specification, and they don't work well with dependabot PRs and long URLs in PR descriptions.