### PR TITLE
[Merged by Bors] - fix(ci): checkout repository in pull request check job to get config file

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!startsWith(github.event.pull_request.title, '[Merged by Bors] - ')"
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - run: npm install @commitlint/config-conventional
       - run: npx commitlint <<< $CONVENTIONAL_COMMIT


### PR DESCRIPTION
Now that there is a config file for conventional commits we should also checkout the repo in the conventional commits check job of the pull request workflow.