### PR TITLE
[Merged by Bors] - chore: update gix to 0.44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [build-dependencies]
-gix = { version = "0.43", default-features = false }
+gix = { version = "0.44", default-features = false }
 heck = "0.4"
 pbjson-build = { version = "0.5", optional = true }
 prettyplease = "0.2.4"


### PR DESCRIPTION
0.43 seems to fail after 0.44 was published, see
  https://github.com/apache/arrow-datafusion/issues/6132 .