### PR TITLE
[Merged by Bors] - chore: use `git2` instead of `gix` to reduce dependency graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [build-dependencies]
-gix = { version = "0.44", default-features = false }
+git2 = { version = "0.17.1", default-features = false }
 heck = "0.4"
 pbjson-build = { version = "0.5", optional = true }
 prettyplease = "0.2.4"


### PR DESCRIPTION
Use [git2](https://docs.rs/git2/latest/git2/) instead of [gix](https://docs.rs/gix/latest/gix/) to reduce the dependency graph. 

Closes #100. 

<details>
  <summary>build dependencies after</summary>

```
[build-dependencies]
├── git2 v0.17.1
│   ├── bitflags v1.3.2
│   ├── libc v0.2.139
│   ├── libgit2-sys v0.15.1+1.6.4
│   │   ├── libc v0.2.139
│   │   └── libz-sys v1.1.9
│   │       └── libc v0.2.139
│   │       [build-dependencies]
│   │       ├── cc v1.0.79
│   │       │   └── jobserver v0.1.26
│   │       │       └── libc v0.2.139
│   │       └── pkg-config v0.3.27
│   │   [build-dependencies]
│   │   ├── cc v1.0.79 (*)
│   │   └── pkg-config v0.3.27
│   ├── log v0.4.17
│   │   └── cfg-if v1.0.0
│   └── url v2.3.1
│       ├── form_urlencoded v1.1.0
│       │   └── percent-encoding v2.2.0
│       ├── idna v0.3.0
│       │   ├── unicode-bidi v0.3.13
│       │   └── unicode-normalization v0.1.22
│       │       └── tinyvec v1.6.0
│       │           └── tinyvec_macros v0.1.1
│       └── percent-encoding v2.2.0
├── heck v0.4.1
├── prettyplease v0.2.4
│   ├── proc-macro2 v1.0.53 (*)
│   └── syn v2.0.11 (*)
├── prost-build v0.11.8
│   ├── bytes v1.4.0
│   ├── heck v0.4.1
│   ├── itertools v0.10.5 (*)
│   ├── lazy_static v1.4.0
│   ├── log v0.4.17 (*)
│   ├── multimap v0.8.3
│   ├── petgraph v0.6.2
│   │   ├── fixedbitset v0.4.2
│   │   └── indexmap v1.9.2
│   │       └── hashbrown v0.12.3
│   │       [build-dependencies]
│   │       └── autocfg v1.1.0
│   ├── prost v0.11.8 (*)
│   ├── prost-types v0.11.8 (*)
│   ├── regex v1.7.1
│   │   └── regex-syntax v0.6.28
│   ├── tempfile v3.4.0
│   │   ├── cfg-if v1.0.0
│   │   ├── fastrand v1.8.0
│   │   └── rustix v0.36.9
│   │       ├── bitflags v1.3.2
│   │       ├── errno v0.2.8
│   │       │   └── libc v0.2.139
│   │       ├── io-lifetimes v1.0.6
│   │       │   └── libc v0.2.139
│   │       └── libc v0.2.139
│   └── which v4.4.0
│       ├── either v1.8.1
│       └── libc v0.2.139
├── prost-types v0.11.8 (*)
├── schemars v0.8.12
│   ├── dyn-clone v1.0.10
│   ├── schemars_derive v0.8.12 (proc-macro)
│   │   ├── proc-macro2 v1.0.53 (*)
│   │   ├── quote v1.0.26 (*)
│   │   ├── serde_derive_internals v0.26.0
│   │   │   ├── proc-macro2 v1.0.53 (*)
│   │   │   ├── quote v1.0.26 (*)
│   │   │   └── syn v1.0.107 (*)
│   │   └── syn v1.0.107 (*)
│   ├── serde v1.0.158 (*)
│   └── serde_json v1.0.94 (*)
├── semver v1.0.17
├── serde_yaml v0.9.19
│   ├── indexmap v1.9.2 (*)
│   ├── itoa v1.0.5
│   ├── ryu v1.0.12
│   ├── serde v1.0.158 (*)
│   └── unsafe-libyaml v0.2.7
├── syn v2.0.11 (*)
├── typify v0.0.11
│   ├── typify-impl v0.0.11
│   │   ├── heck v0.4.1
│   │   ├── log v0.4.17 (*)
│   │   ├── proc-macro2 v1.0.53 (*)
│   │   ├── quote v1.0.26 (*)
│   │   ├── regress v0.5.0
│   │   │   ├── hashbrown v0.13.2
│   │   │   │   └── ahash v0.8.3
│   │   │   │       ├── cfg-if v1.0.0
│   │   │   │       └── once_cell v1.17.1
│   │   │   │       [build-dependencies]
│   │   │   │       └── version_check v0.9.4
│   │   │   └── memchr v2.5.0
│   │   ├── schemars v0.8.12 (*)
│   │   ├── serde_json v1.0.94 (*)
│   │   ├── syn v1.0.107 (*)
│   │   ├── thiserror v1.0.40
│   │   │   └── thiserror-impl v1.0.40 (proc-macro)
│   │   │       ├── proc-macro2 v1.0.53 (*)
│   │   │       ├── quote v1.0.26 (*)
│   │   │       └── syn v2.0.11 (*)
│   │   └── unicode-ident v1.0.8
│   └── typify-macro v0.0.11 (proc-macro)
│       ├── proc-macro2 v1.0.53 (*)
│       ├── quote v1.0.26 (*)
│       ├── schemars v0.8.12 (*)
│       ├── serde v1.0.158 (*)
│       ├── serde_json v1.0.94 (*)
│       ├── serde_tokenstream v0.1.7
│       │   ├── proc-macro2 v1.0.53 (*)
│       │   ├── serde v1.0.158 (*)
│       │   └── syn v1.0.107 (*)
│       ├── syn v1.0.107 (*)
│       └── typify-impl v0.0.11 (*)
└── walkdir v2.3.3
    └── same-file v1.0.6
```

</details>


<details>
  <summary>build dependencies before</summary>

```
[build-dependencies]
├── gix v0.44.1
│   ├── gix-actor v0.20.0
│   │   ├── bstr v1.4.0
│   │   │   ├── memchr v2.5.0
│   │   │   ├── once_cell v1.17.1
│   │   │   └── regex-automata v0.1.10
│   │   ├── btoi v0.4.3
│   │   │   └── num-traits v0.2.15
│   │   │       [build-dependencies]
│   │   │       └── autocfg v1.1.0
│   │   ├── gix-date v0.5.0
│   │   │   ├── bstr v1.4.0 (*)
│   │   │   ├── itoa v1.0.5
│   │   │   ├── thiserror v1.0.40
│   │   │   │   └── thiserror-impl v1.0.40 (proc-macro)
│   │   │   │       ├── proc-macro2 v1.0.53 (*)
│   │   │   │       ├── quote v1.0.26 (*)
│   │   │   │       └── syn v2.0.11 (*)
│   │   │   └── time v0.3.21
│   │   │       ├── itoa v1.0.5
│   │   │       ├── libc v0.2.143
│   │   │       ├── num_threads v0.1.6
│   │   │       │   └── libc v0.2.143
│   │   │       ├── time-core v0.1.1
│   │   │       └── time-macros v0.2.9 (proc-macro)
│   │   │           └── time-core v0.1.1
│   │   ├── itoa v1.0.5
│   │   ├── nom v7.1.3
│   │   │   ├── memchr v2.5.0
│   │   │   └── minimal-lexical v0.2.1
│   │   └── thiserror v1.0.40 (*)
│   ├── gix-attributes v0.12.0
│   │   ├── bstr v1.4.0 (*)
│   │   ├── gix-glob v0.7.0
│   │   │   ├── bitflags v2.2.1
│   │   │   ├── bstr v1.4.0 (*)
│   │   │   ├── gix-features v0.29.0
│   │   │   │   ├── crc32fast v1.3.2
│   │   │   │   │   └── cfg-if v1.0.0
│   │   │   │   ├── flate2 v1.0.26
│   │   │   │   │   ├── crc32fast v1.3.2 (*)
│   │   │   │   │   └── miniz_oxide v0.7.1
│   │   │   │   │       └── adler v1.0.2
│   │   │   │   ├── gix-hash v0.11.1
│   │   │   │   │   ├── hex v0.4.3
│   │   │   │   │   └── thiserror v1.0.40 (*)
│   │   │   │   ├── libc v0.2.143
│   │   │   │   ├── once_cell v1.17.1
│   │   │   │   ├── prodash v23.1.2
│   │   │   │   ├── sha1_smol v1.0.0
│   │   │   │   ├── thiserror v1.0.40 (*)
│   │   │   │   └── walkdir v2.3.3
│   │   │   │       └── same-file v1.0.6
│   │   │   └── gix-path v0.8.0
│   │   │       ├── bstr v1.4.0 (*)
│   │   │       ├── home v0.5.5
│   │   │       ├── once_cell v1.17.1
│   │   │       └── thiserror v1.0.40 (*)
│   │   ├── gix-path v0.8.0 (*)
│   │   ├── gix-quote v0.4.3
│   │   │   ├── bstr v1.4.0 (*)
│   │   │   ├── btoi v0.4.3 (*)
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── kstring v2.0.0
│   │   │   └── static_assertions v1.1.0
│   │   ├── log v0.4.17
│   │   │   └── cfg-if v1.0.0
│   │   ├── smallvec v1.10.0
│   │   ├── thiserror v1.0.40 (*)
│   │   └── unicode-bom v2.0.2
│   ├── gix-config v0.22.0
│   │   ├── bstr v1.4.0 (*)
│   │   ├── gix-config-value v0.12.0
│   │   │   ├── bitflags v2.2.1
│   │   │   ├── bstr v1.4.0 (*)
│   │   │   ├── gix-path v0.8.0 (*)
│   │   │   ├── libc v0.2.143
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── gix-features v0.29.0 (*)
│   │   ├── gix-glob v0.7.0 (*)
│   │   ├── gix-path v0.8.0 (*)
│   │   ├── gix-ref v0.29.1
│   │   │   ├── gix-actor v0.20.0 (*)
│   │   │   ├── gix-features v0.29.0 (*)
│   │   │   ├── gix-fs v0.1.1
│   │   │   │   └── gix-features v0.29.0 (*)
│   │   │   ├── gix-hash v0.11.1 (*)
│   │   │   ├── gix-lock v5.0.1
│   │   │   │   ├── gix-tempfile v5.0.3
│   │   │   │   │   ├── gix-fs v0.1.1 (*)
│   │   │   │   │   ├── libc v0.2.143
│   │   │   │   │   ├── once_cell v1.17.1
│   │   │   │   │   ├── parking_lot v0.12.1
│   │   │   │   │   │   ├── lock_api v0.4.9
│   │   │   │   │   │   │   └── scopeguard v1.1.0
│   │   │   │   │   │   │   [build-dependencies]
│   │   │   │   │   │   │   └── autocfg v1.1.0
│   │   │   │   │   │   └── parking_lot_core v0.9.7
│   │   │   │   │   │       ├── cfg-if v1.0.0
│   │   │   │   │   │       ├── libc v0.2.143
│   │   │   │   │   │       └── smallvec v1.10.0
│   │   │   │   │   ├── signal-hook v0.3.15
│   │   │   │   │   │   ├── libc v0.2.143
│   │   │   │   │   │   └── signal-hook-registry v1.4.1
│   │   │   │   │   │       └── libc v0.2.143
│   │   │   │   │   ├── signal-hook-registry v1.4.1 (*)
│   │   │   │   │   └── tempfile v3.4.0
│   │   │   │   │       ├── cfg-if v1.0.0
│   │   │   │   │       ├── fastrand v1.9.0
│   │   │   │   │       └── rustix v0.36.9
│   │   │   │   │           ├── bitflags v1.3.2
│   │   │   │   │           ├── errno v0.2.8
│   │   │   │   │           │   └── libc v0.2.143
│   │   │   │   │           ├── io-lifetimes v1.0.10
│   │   │   │   │           │   └── libc v0.2.143
│   │   │   │   │           └── libc v0.2.143
│   │   │   │   ├── gix-utils v0.1.1
│   │   │   │   │   └── fastrand v1.9.0
│   │   │   │   └── thiserror v1.0.40 (*)
│   │   │   ├── gix-object v0.29.1
│   │   │   │   ├── bstr v1.4.0 (*)
│   │   │   │   ├── btoi v0.4.3 (*)
│   │   │   │   ├── gix-actor v0.20.0 (*)
│   │   │   │   ├── gix-features v0.29.0 (*)
│   │   │   │   ├── gix-hash v0.11.1 (*)
│   │   │   │   ├── gix-validate v0.7.4
│   │   │   │   │   ├── bstr v1.4.0 (*)
│   │   │   │   │   └── thiserror v1.0.40 (*)
│   │   │   │   ├── hex v0.4.3
│   │   │   │   ├── itoa v1.0.5
│   │   │   │   ├── nom v7.1.3 (*)
│   │   │   │   ├── smallvec v1.10.0
│   │   │   │   └── thiserror v1.0.40 (*)
│   │   │   ├── gix-path v0.8.0 (*)
│   │   │   ├── gix-tempfile v5.0.3 (*)
│   │   │   ├── gix-validate v0.7.4 (*)
│   │   │   ├── memmap2 v0.5.10
│   │   │   │   └── libc v0.2.143
│   │   │   ├── nom v7.1.3 (*)
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── gix-sec v0.8.0
│   │   │   ├── bitflags v2.2.1
│   │   │   └── libc v0.2.143
│   │   ├── log v0.4.17 (*)
│   │   ├── memchr v2.5.0
│   │   ├── nom v7.1.3 (*)
│   │   ├── once_cell v1.17.1
│   │   ├── smallvec v1.10.0
│   │   ├── thiserror v1.0.40 (*)
│   │   └── unicode-bom v2.0.2
│   ├── gix-credentials v0.14.0
│   │   ├── bstr v1.4.0 (*)
│   │   ├── gix-command v0.2.4
│   │   │   └── bstr v1.4.0 (*)
│   │   ├── gix-config-value v0.12.0 (*)
│   │   ├── gix-path v0.8.0 (*)
│   │   ├── gix-prompt v0.5.0
│   │   │   ├── gix-command v0.2.4 (*)
│   │   │   ├── gix-config-value v0.12.0 (*)
│   │   │   ├── parking_lot v0.12.1 (*)
│   │   │   ├── rustix v0.37.19
│   │   │   │   ├── bitflags v1.3.2
│   │   │   │   ├── errno v0.3.1
│   │   │   │   │   └── libc v0.2.143
│   │   │   │   ├── io-lifetimes v1.0.10 (*)
│   │   │   │   └── libc v0.2.143
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── gix-sec v0.8.0 (*)
│   │   ├── gix-url v0.18.0
│   │   │   ├── bstr v1.4.0 (*)
│   │   │   ├── gix-features v0.29.0 (*)
│   │   │   ├── gix-path v0.8.0 (*)
│   │   │   ├── home v0.5.5
│   │   │   ├── thiserror v1.0.40 (*)
│   │   │   └── url v2.3.1
│   │   │       ├── form_urlencoded v1.1.0
│   │   │       │   └── percent-encoding v2.2.0
│   │   │       ├── idna v0.3.0
│   │   │       │   ├── unicode-bidi v0.3.13
│   │   │       │   └── unicode-normalization v0.1.22
│   │   │       │       └── tinyvec v1.6.0
│   │   │       │           └── tinyvec_macros v0.1.1
│   │   │       └── percent-encoding v2.2.0
│   │   └── thiserror v1.0.40 (*)
│   ├── gix-date v0.5.0 (*)
│   ├── gix-diff v0.29.0
│   │   ├── gix-hash v0.11.1 (*)
│   │   ├── gix-object v0.29.1 (*)
│   │   ├── imara-diff v0.1.5
│   │   │   ├── ahash v0.8.3
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   ├── getrandom v0.2.9
│   │   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   │   └── libc v0.2.143
│   │   │   │   └── once_cell v1.17.1
│   │   │   │   [build-dependencies]
│   │   │   │   └── version_check v0.9.4
│   │   │   └── hashbrown v0.12.3
│   │   └── thiserror v1.0.40 (*)
│   ├── gix-discover v0.18.1
│   │   ├── bstr v1.4.0 (*)
│   │   ├── gix-hash v0.11.1 (*)
│   │   ├── gix-path v0.8.0 (*)
│   │   ├── gix-ref v0.29.1 (*)
│   │   ├── gix-sec v0.8.0 (*)
│   │   └── thiserror v1.0.40 (*)
│   ├── gix-features v0.29.0 (*)
│   ├── gix-fs v0.1.1 (*)
│   ├── gix-glob v0.7.0 (*)
│   ├── gix-hash v0.11.1 (*)
│   ├── gix-hashtable v0.2.0
│   │   ├── gix-hash v0.11.1 (*)
│   │   ├── hashbrown v0.13.2
│   │   │   └── ahash v0.8.3 (*)
│   │   └── parking_lot v0.12.1 (*)
│   ├── gix-ignore v0.2.0
│   │   ├── bstr v1.4.0 (*)
│   │   ├── gix-glob v0.7.0 (*)
│   │   ├── gix-path v0.8.0 (*)
│   │   └── unicode-bom v2.0.2
│   ├── gix-index v0.16.1
│   │   ├── bitflags v2.2.1
│   │   ├── bstr v1.4.0 (*)
│   │   ├── btoi v0.4.3 (*)
│   │   ├── filetime v0.2.21
│   │   │   ├── cfg-if v1.0.0
│   │   │   └── libc v0.2.143
│   │   ├── gix-bitmap v0.2.3
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── gix-features v0.29.0 (*)
│   │   ├── gix-hash v0.11.1 (*)
│   │   ├── gix-lock v5.0.1 (*)
│   │   ├── gix-object v0.29.1 (*)
│   │   ├── gix-traverse v0.25.0
│   │   │   ├── gix-hash v0.11.1 (*)
│   │   │   ├── gix-hashtable v0.2.0 (*)
│   │   │   ├── gix-object v0.29.1 (*)
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── itoa v1.0.5
│   │   ├── memmap2 v0.5.10 (*)
│   │   ├── smallvec v1.10.0
│   │   └── thiserror v1.0.40 (*)
│   ├── gix-lock v5.0.1 (*)
│   ├── gix-mailmap v0.12.0
│   │   ├── bstr v1.4.0 (*)
│   │   ├── gix-actor v0.20.0 (*)
│   │   └── thiserror v1.0.40 (*)
│   ├── gix-object v0.29.1 (*)
│   ├── gix-odb v0.45.0
│   │   ├── arc-swap v1.6.0
│   │   ├── gix-features v0.29.0 (*)
│   │   ├── gix-hash v0.11.1 (*)
│   │   ├── gix-object v0.29.1 (*)
│   │   ├── gix-pack v0.35.0
│   │   │   ├── clru v0.6.1
│   │   │   ├── gix-chunk v0.4.1
│   │   │   │   └── thiserror v1.0.40 (*)
│   │   │   ├── gix-diff v0.29.0 (*)
│   │   │   ├── gix-features v0.29.0 (*)
│   │   │   ├── gix-hash v0.11.1 (*)
│   │   │   ├── gix-hashtable v0.2.0 (*)
│   │   │   ├── gix-object v0.29.1 (*)
│   │   │   ├── gix-path v0.8.0 (*)
│   │   │   ├── gix-tempfile v5.0.3 (*)
│   │   │   ├── gix-traverse v0.25.0 (*)
│   │   │   ├── memmap2 v0.5.10 (*)
│   │   │   ├── parking_lot v0.12.1 (*)
│   │   │   ├── smallvec v1.10.0
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── gix-path v0.8.0 (*)
│   │   ├── gix-quote v0.4.3 (*)
│   │   ├── parking_lot v0.12.1 (*)
│   │   ├── tempfile v3.4.0 (*)
│   │   └── thiserror v1.0.40 (*)
│   ├── gix-pack v0.35.0 (*)
│   ├── gix-path v0.8.0 (*)
│   ├── gix-prompt v0.5.0 (*)
│   ├── gix-ref v0.29.1 (*)
│   ├── gix-refspec v0.10.1
│   │   ├── bstr v1.4.0 (*)
│   │   ├── gix-hash v0.11.1 (*)
│   │   ├── gix-revision v0.13.0
│   │   │   ├── bstr v1.4.0 (*)
│   │   │   ├── gix-date v0.5.0 (*)
│   │   │   ├── gix-hash v0.11.1 (*)
│   │   │   ├── gix-hashtable v0.2.0 (*)
│   │   │   ├── gix-object v0.29.1 (*)
│   │   │   └── thiserror v1.0.40 (*)
│   │   ├── gix-validate v0.7.4 (*)
│   │   ├── smallvec v1.10.0
│   │   └── thiserror v1.0.40 (*)
│   ├── gix-revision v0.13.0 (*)
│   ├── gix-sec v0.8.0 (*)
│   ├── gix-tempfile v5.0.3 (*)
│   ├── gix-traverse v0.25.0 (*)
│   ├── gix-url v0.18.0 (*)
│   ├── gix-utils v0.1.1 (*)
│   ├── gix-validate v0.7.4 (*)
│   ├── gix-worktree v0.17.1
│   │   ├── bstr v1.4.0 (*)
│   │   ├── filetime v0.2.21 (*)
│   │   ├── gix-attributes v0.12.0 (*)
│   │   ├── gix-features v0.29.0 (*)
│   │   ├── gix-fs v0.1.1 (*)
│   │   ├── gix-glob v0.7.0 (*)
│   │   ├── gix-hash v0.11.1 (*)
│   │   ├── gix-ignore v0.2.0 (*)
│   │   ├── gix-index v0.16.1 (*)
│   │   ├── gix-object v0.29.1 (*)
│   │   ├── gix-path v0.8.0 (*)
│   │   ├── io-close v0.3.7
│   │   │   └── libc v0.2.143
│   │   └── thiserror v1.0.40 (*)
│   ├── log v0.4.17 (*)
│   ├── once_cell v1.17.1
│   ├── signal-hook v0.3.15 (*)
│   ├── smallvec v1.10.0
│   ├── thiserror v1.0.40 (*)
│   └── unicode-normalization v0.1.22 (*)
├── heck v0.4.1
├── prettyplease v0.2.4
│   ├── proc-macro2 v1.0.53 (*)
│   └── syn v2.0.11 (*)
├── prost-build v0.11.8
│   ├── bytes v1.4.0
│   ├── heck v0.4.1
│   ├── itertools v0.10.5 (*)
│   ├── lazy_static v1.4.0
│   ├── log v0.4.17 (*)
│   ├── multimap v0.8.3
│   ├── petgraph v0.6.2
│   │   ├── fixedbitset v0.4.2
│   │   └── indexmap v1.9.2
│   │       └── hashbrown v0.12.3
│   │       [build-dependencies]
│   │       └── autocfg v1.1.0
│   ├── prost v0.11.8 (*)
│   ├── prost-types v0.11.8 (*)
│   ├── regex v1.7.1
│   │   └── regex-syntax v0.6.28
│   ├── tempfile v3.4.0 (*)
│   └── which v4.4.0
│       ├── either v1.8.1
│       └── libc v0.2.143
├── prost-types v0.11.8 (*)
├── schemars v0.8.12
│   ├── dyn-clone v1.0.10
│   ├── schemars_derive v0.8.12 (proc-macro)
│   │   ├── proc-macro2 v1.0.53 (*)
│   │   ├── quote v1.0.26 (*)
│   │   ├── serde_derive_internals v0.26.0
│   │   │   ├── proc-macro2 v1.0.53 (*)
│   │   │   ├── quote v1.0.26 (*)
│   │   │   └── syn v1.0.107 (*)
│   │   └── syn v1.0.107 (*)
│   ├── serde v1.0.158 (*)
│   └── serde_json v1.0.94 (*)
├── semver v1.0.17
├── serde_yaml v0.9.19
│   ├── indexmap v1.9.2 (*)
│   ├── itoa v1.0.5
│   ├── ryu v1.0.12
│   ├── serde v1.0.158 (*)
│   └── unsafe-libyaml v0.2.7
├── syn v2.0.11 (*)
├── typify v0.0.11
│   ├── typify-impl v0.0.11
│   │   ├── heck v0.4.1
│   │   ├── log v0.4.17 (*)
│   │   ├── proc-macro2 v1.0.53 (*)
│   │   ├── quote v1.0.26 (*)
│   │   ├── regress v0.5.0
│   │   │   ├── hashbrown v0.13.2 (*)
│   │   │   └── memchr v2.5.0
│   │   ├── schemars v0.8.12 (*)
│   │   ├── serde_json v1.0.94 (*)
│   │   ├── syn v1.0.107 (*)
│   │   ├── thiserror v1.0.40 (*)
│   │   └── unicode-ident v1.0.8
│   └── typify-macro v0.0.11 (proc-macro)
│       ├── proc-macro2 v1.0.53 (*)
│       ├── quote v1.0.26 (*)
│       ├── schemars v0.8.12 (*)
│       ├── serde v1.0.158 (*)
│       ├── serde_json v1.0.94 (*)
│       ├── serde_tokenstream v0.1.7
│       │   ├── proc-macro2 v1.0.53 (*)
│       │   ├── serde v1.0.158 (*)
│       │   └── syn v1.0.107 (*)
│       ├── syn v1.0.107 (*)
│       └── typify-impl v0.0.11 (*)
└── walkdir v2.3.3 (*)
```

</details>
