### PR TITLE
chore: bump version to 0.10.0 to fix smart release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name = "substrait"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.60"
 description = "Cross-Language Serialization for Relational Algebra"


### PR DESCRIPTION
Since the release workflow was broken 0.10.0 was pushed to crates.io, but the commit with changelog and version bump was not pushed to main. This fixes the version to make sure the next smart release can bump to 0.11.0.