### PR TITLE
chore(ci): fix doc deployment file permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo rustdoc --features semver -- --cfg docsrs
+      - run: chmod -c -R +rX "target/doc"
+      - run: echo "<meta http-equiv=refresh content=0;url=substrait>" > target/doc/index.html
       - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v1
         with:

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Rust crate for [Substrait](https://substrait.io/): Cross-Language Serialization 
 ## Documentation
 
 - [Docs (release)](https://docs.rs/substrait)
-- [Docs (main)](https://substrait-io.github.io/substrait-rs/substrait/)
+- [Docs (main)](https://substrait-io.github.io/substrait-rs/)


### PR DESCRIPTION
Change required to handle the [failed deploy job](https://github.com/substrait-io/substrait-rs/actions/runs/5438507514/jobs/9889794289). Caused by a change in the `upload-pages-artifact` action: https://github.com/actions/upload-pages-artifact#file-permissions. Also added an index file that redirects the client to the substrait crate docs.