### PR TITLE
fix(ci): release job cargo install cache hit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - run: cargo install cargo-smart-release --debug --locked
+      - run: cargo-smart-release --debug --locked || true
       - run: cargo check --all-features
       - run: cargo changelog --execute substrait
       - run: |


### PR DESCRIPTION
With the addition of a cache in the release workflow we need to handle the case where the tool is already installed.