### PR TITLE
feat: make it possible for downstream users to avoid git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ include = [
 ]
 
 [features]
-default = []
+default = ["git2"]
+git2 = ["dep:git2"]
 parse = ["dep:hex", "dep:thiserror", "dep:url", "semver"]
 protoc = ["dep:protobuf-src"]
 semver = ["dep:semver"]
@@ -44,7 +45,7 @@ serde_json = "1.0.114"
 thiserror = { version = "1.0.57", optional = true }
 
 [build-dependencies]
-git2 = { version = "0.18.2", default-features = false }
+git2 = { version = "0.18.2", default-features = false, optional = true }
 heck = "0.5.0"
 pbjson-build = { version = "0.6.2", optional = true }
 prettyplease = "0.2.4"


### PR DESCRIPTION
Many rust users want to avoid native dependencies as much as possible.  Currently, substrait requires a dependency on `libgit2` which can cause complications in some environments (full disclaimer, we have a request to remove this dependency in lance).

However, `libgit2` isn't even really needed by most users.  It is only required to calculate the `version.in` file but that is already calculated at publish time and included in the package.

This PR makes `git2` a feature so that downstream users can turn it off.  If the feature is off, and the `version.in` file is missing, then the build will fail.  Ideally, `git2` would also not need to be a default feature, but I can't find anyway to pass a `-F git2` option to `cargo publish` using `cargo smart-release`.  So there is still room for improvement if anyone has any good ideas.