### PR TITLE
feat: directly call `git` to get substrait submodule version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde_json = "1.0.114"
 thiserror = { version = "1.0.57", optional = true }
 
 [build-dependencies]
-git-version = "0.3.9"
 heck = "0.5.0"
 pbjson-build = { version = "0.6.2", optional = true }
 prettyplease = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name = "substrait"
-version = "0.29.1"
+version = "0.29.2"
 edition = "2021"
 rust-version = "1.60"
 description = "Cross-Language Serialization for Relational Algebra"

--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,7 @@ fn substrait_version() -> Result<(), Box<dyn Error>> {
         // Get the version of the submodule by directly calling `git describe`.
         let version = String::from_utf8(
             Command::new("git")
-                .current_dir("substrait")
+                .current_dir(SUBMODULE_ROOT)
                 .arg("describe")
                 .arg("--tags")
                 .arg("--long")

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,7 +8,7 @@
 
 use crate::proto::Version;
 
-include!("version.in");
+include!("../gen/version.in");
 
 /// Returns the version of Substrait used to build this crate.
 ///


### PR DESCRIPTION
Same idea as #173, except this directly calls `git describe` at build time (when there is a submodule).