### PR TITLE
docs: `--cfg=docsrs` is now a default set by docs.rs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ jobs:
   rustdoc:
     name: Rustdoc
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,20 +25,9 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@nightly
         id: rust-toolchain
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-rustdoc-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-rustdoc-
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
-            ${{ runner.os }}-cargo-
-      - run: cargo rustdoc --all-features -- --cfg docsrs
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs
+      - run: mv "target/$(rustc -vV | awk '/^host/ { print $2 }')/doc" "target/doc"
       - run: chmod -c -R +rX "target/doc"
       - run: echo "<meta http-equiv=refresh content=0;url=substrait>" > target/doc/index.html
       - if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,12 @@ Or to enable automatic feature information (requires a nightly toolchain):
 cargo +nightly rustdoc -- --cfg docsrs
 ```
 
+Or use [cargo-doc-rs](https://crates.io/crates/cargo-docs-rs):
+
+```
+cargo +nightly docs-rs
+```
+
 ### Formatting
 
 All Rust code is formatted using [rustfmt](https://github.com/rust-lang/rustfmt):

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,3 @@ walkdir = "2.5.0"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/src/parse/proto/extensions/mod.rs
+++ b/src/parse/proto/extensions/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Parsing of [proto::extensions] types.
+//! Parsing of [crate::proto::extensions] types.
 
 mod simple_extension_uri;
 pub use simple_extension_uri::SimpleExtensionUri;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -3,7 +3,8 @@
 #![allow(
     clippy::large_enum_variant,
     clippy::needless_borrow,
-    clippy::needless_borrows_for_generic_args
+    clippy::needless_borrows_for_generic_args,
+    rustdoc::invalid_html_tags
 )]
 
 //! Generated types for the protobuf `substrait` package.


### PR DESCRIPTION
It's no longer required to specify this in our package metadata.