### PR TITLE
chore: add `prost` and `pbjson` dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
     rebase-strategy: "disabled"
     commit-message:
       prefix: "chore(deps,cargo)"
+    groups:
+      prost:
+        applies-to: version-updates
+        patterns:
+          - "prost*"
+      pbjson:
+        applies-to: version-updates
+        patterns:
+          - "pbjson*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This groups the dependabot updates of these packages together.