### PR TITLE
ci: use previous rust release to build smart release with lock file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.79 # revert to stable on next smart-release release
         id: rust-toolchain
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
The smart-release lock file is pointing to an outdated version of `time` that fails to build on the latest stable rustc. Reverting to the previous stable release until the next smart-release release.