### PR TITLE
chore(deps,cargo): revert bump once_cell from 1.19.0 to 1.20.0 in the cargo group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "pbjson"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde = ["dep:pbjson", "dep:pbjson-build", "dep:pbjson-types"]
 
 [dependencies]
 hex = { version = "0.4.3", optional = true }
-once_cell = { version = "1.20.0", optional = true }
+once_cell = { version = "1.19.0", optional = true }
 pbjson = { version = "0.7.0", optional = true }
 pbjson-types = { version = "0.7.0", optional = true }
 prost = "0.13.2"


### PR DESCRIPTION
Reverts substrait-io/substrait-rs#226. The release was yanked.