### PR TITLE
refactor: replace `once_cell` with `std::sync::LazyLock`, bumping msrv to `1.80.1`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.75.0
+      - uses: dtolnay/rust-toolchain@1.80.1
         id: rust-toolchain
       - uses: actions/cache@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,6 @@ version = "0.49.1"
 dependencies = [
  "heck",
  "hex",
- "once_cell",
  "pbjson",
  "pbjson-build",
  "pbjson-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "substrait"
 version = "0.49.1"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.80.1"
 description = "Cross-Language Serialization for Relational Algebra"
 documentation = "https://docs.rs/substrait"
 readme = "README.md"
@@ -26,7 +26,7 @@ include = [
 
 [features]
 default = []
-extensions = ["dep:once_cell", "dep:serde_yaml"]
+extensions = ["dep:serde_yaml"]
 parse = ["dep:hex", "dep:thiserror", "dep:url", "semver"]
 protoc = ["dep:protobuf-src"]
 semver = ["dep:semver"]
@@ -34,7 +34,6 @@ serde = ["dep:pbjson", "dep:pbjson-build", "dep:pbjson-types"]
 
 [dependencies]
 hex = { version = "0.4.3", optional = true }
-once_cell = { version = "1.20.2", optional = true }
 pbjson = { version = "0.7.0", optional = true }
 pbjson-types = { version = "0.7.0", optional = true }
 prost = "0.13.3"

--- a/build.rs
+++ b/build.rs
@@ -230,12 +230,12 @@ const {var_name}: &str = include_str!("{}/{}");
         r#"
 use std::collections::HashMap;
 use std::str::FromStr;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use crate::text::simple_extensions::SimpleExtensions;
 use url::Url;
 
 /// Map with Substrait core extensions. Maps URIs to included extensions.
-pub static EXTENSIONS: Lazy<HashMap<Url, SimpleExtensions>> = Lazy::new(|| {
+pub static EXTENSIONS: LazyLock<HashMap<Url, SimpleExtensions>> = LazyLock::new(|| {
     let mut map = HashMap::new();"#,
     );
 

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -12,11 +12,11 @@ include!(concat!(env!("OUT_DIR"), "/extensions.in"));
 mod tests {
     use super::*;
 
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     #[test]
     fn core_extensions() {
         // Force evaluation of core extensions.
-        Lazy::force(&EXTENSIONS);
+        LazyLock::force(&EXTENSIONS);
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -4,6 +4,7 @@
     clippy::large_enum_variant,
     clippy::needless_borrow,
     clippy::needless_borrows_for_generic_args,
+    clippy::needless_lifetimes,
     rustdoc::invalid_html_tags
 )]
 


### PR DESCRIPTION
Removes the `once_cell` dependency, replacing it with `std::sync::LazyLock`, stabilized in Rust `1.80`.