### PR TITLE
fix: use `1.80.0` instead of `1.80.1` for msrv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.80.1
+      - uses: dtolnay/rust-toolchain@1.80.0
         id: rust-toolchain
       - uses: actions/cache@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "substrait"
 version = "0.49.5"
 edition = "2021"
-rust-version = "1.80.1"
+rust-version = "1.80.0"
 description = "Cross-Language Serialization for Relational Algebra"
 documentation = "https://docs.rs/substrait"
 readme = "README.md"


### PR DESCRIPTION
Using the patch version caused some problems in https://github.com/apache/datafusion/issues/13653.