### PR TITLE
ci(release): use `release-plz`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@
 
 name: Release
 
+permissions:
+  pull-requests: write
+  contents: write
+
 on:
   push:
     branches:
@@ -11,7 +15,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    concurrency: release
+    environment:
+      name: crates-io
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,34 +28,28 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-      - uses: actions/cache@v4
+      - uses: MarcoIeni/release-plz-action@v0.5.88
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
-            ${{ runner.os }}-cargo-
-      - run: cargo install cargo-smart-release --locked || true
-      - run: cargo check --all-features
-      - run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - env:
-          GH_TOKEN: ${{ github.token }}
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: |
-          cargo smart-release \
-            --update-crates-index \
-            --allow-fully-generated-changelogs \
-            --execute \
-            --no-changelog-preview \
-            --allow-dirty \
-            --verbose \
-            substrait
+
+  pr:
+    name: PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: MarcoIeni/release-plz-action@v0.5.88
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+[workspace]
+release_always = false
+
+[[package]]
+name = "substrait"


### PR DESCRIPTION
This gives us a release PR that triggers a new release when merged, instead of always releasing on push to main. The goal is not to reduce the release frequency, but to skip releases on `Cargo.lock` changes, because these releases are useless for dependents.