### PR TITLE
fix(release): trigger build script before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
+      # Trigger build script to generate version info
+      - run: cargo build
       - uses: MarcoIeni/release-plz-action@v0.5.89
         with:
           command: release

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,3 +3,4 @@ release_always = false
 
 [[package]]
 name = "substrait"
+publish_allow_dirty = true


### PR DESCRIPTION
We need to run the build script to generate version information:

https://github.com/substrait-io/substrait-rs/blob/a54d8ecaf853d4104e28668010666bd9b7cb7c02/src/version.rs#L11

This also means we need to set `publish_allow_dirty` to make the published package include those generated files.