### PR TITLE
chore: undo release v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,3 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-## [0.53.0](https://github.com/substrait-io/substrait-rs/compare/v0.52.3...v0.53.0) - 2025-02-02
-
-### Other
-
-- *(deps,cargo)* bump protobuf-src from 2.1.0+27.1 to 2.1.1+27.1 in the cargo group (#289)
-- *(deps,cargo)* bump serde_json from 1.0.137 to 1.0.138 in the cargo group (#287)
 
 
 ## 0.52.3 (2025-01-21)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "substrait"
-version = "0.53.0"
+version = "0.52.3"
 dependencies = [
  "heck",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name = "substrait"
-version = "0.53.0"
+version = "0.52.3"
 edition = "2021"
 rust-version = "1.80.1"
 description = "Cross-Language Serialization for Relational Algebra"


### PR DESCRIPTION
Reverts substrait-io/substrait-rs#288. The release job failed. This should trigger a retry (new PR) with the fix from #291 when merged to main.