### PR TITLE
chore(release): update generated files before running release-plz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,14 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo build
       - uses: MarcoIeni/release-plz-action@v0.5.94
         with:
           command: release-pr
         env:
+          RUST_LOG: debug
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
`substrait` submodule update commits currently don't trigger a release PR. This is an attempt to fix that.