### PR TITLE
chore(release)!: skip semver check

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,6 @@
 [workspace]
 release_always = false
+semver_check = false
 
 [[package]]
 name = "substrait"


### PR DESCRIPTION
It seems release-plz gets a bit confused because sometimes our submodule update only results in changes in generated files, which are not picked up by the semver check. Maybe this improves the version bump result.