### PR TITLE
feat!: add substrait version const to trigger semver check on substrait update

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -98,6 +98,11 @@ pub const SUBSTRAIT_GIT_DEPTH: u32 = {git_depth};
 
 /// The dirty state of the Substrait submodule used to build this crate
 pub const SUBSTRAIT_GIT_DIRTY: bool = {git_dirty};
+
+/// A constant with the Substrait version as name, to trigger semver bumps when
+/// the Substrait version changes.
+#[doc(hidden)]
+pub const SUBSTRAIT_{major}_{minor}_{patch}: () = ();
 "#
             ),
         )?;

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,5 @@
 [workspace]
 release_always = false
-semver_check = false
 
 [[package]]
 name = "substrait"


### PR DESCRIPTION
We want release-plz to trigger a version bump when we change the substrait version. Because we generate files it seems that is's not always picking that up correct (e.g. when it's just a documentation change - which could be breaking). This reverts #331. 