### PR TITLE
fix: remove `doc(hidden)` from version const to fix semver checks

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -101,7 +101,6 @@ pub const SUBSTRAIT_GIT_DIRTY: bool = {git_dirty};
 
 /// A constant with the Substrait version as name, to trigger semver bumps when
 /// the Substrait version changes.
-#[doc(hidden)]
 pub const SUBSTRAIT_{major}_{minor}_{patch}: () = ();
 "#
             ),


### PR DESCRIPTION
[`doc(hidden)` items are not considered part of the public API](https://github.com/obi1kenobi/cargo-semver-checks/blob/f710a448f949a7eeba17eb14ea90f81ab232bc7f/src/lints/pub_module_level_const_now_doc_hidden.ron#L4) and ignored by cargo semver check. We'll have to revisit this when substrait gets to 1.0.