### PR TITLE
feat: allow unknown fields in protobuf JSON for forward compat

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -286,6 +286,7 @@ fn serde(protos: &[impl AsRef<Path>], out_dir: PathBuf) -> Result<(), Box<dyn Er
 
     Builder::new()
         .register_descriptors(&fs::read(descriptor_path)?)?
+        .ignore_unknown_fields()
         .build(&[".substrait"])?;
 
     Ok(())

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -51,4 +51,34 @@ mod tests {
         assert_eq!(plan.extension_urns.len(), 1);
         Ok(())
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn forward_compatible_unknown_fields() -> Result<(), Box<dyn std::error::Error>> {
+        // Test that unknown fields are ignored for forward compatibility
+        let plan = serde_json::from_str::<super::Plan>(
+            r#"{
+  "version": { "minorNumber": 75, "producer": "substrait-rs" },
+  "unknownField": "this field doesn't exist in the proto",
+  "anotherUnknownField": {"nested": "data"},
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 1,
+      "urn": "extension:io.substrait:functions_string",
+      "futureField": "should be ignored"
+    }
+  ]
+}"#,
+        )?;
+        assert_eq!(
+            plan.version,
+            Some(super::Version {
+                minor_number: 75,
+                producer: "substrait-rs".into(),
+                ..Default::default()
+            })
+        );
+        assert_eq!(plan.extension_urns.len(), 1);
+        Ok(())
+    }
 }


### PR DESCRIPTION
JSON deserialization rejects JSON which contains unknown fields. This poses a problem, as future iterations of substrait become forwards-incompatible. This PR allows unknown fields in JSON deserialization. 