### PR TITLE
feat: add file descriptor bytes to substrait-rs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,10 @@ jobs:
       - run: cargo check --all-targets --no-default-features --features protoc,semver
       - run: cargo check --all-targets --no-default-features --features protoc,serde
       - run: cargo check --all-targets --no-default-features --features protoc,parse
+      - run: cargo check --all-targets --no-default-features --features protoc,embed-descriptor
+      # Also check that the serde feature works with the embed-descriptor feature, since the compile
+      # works differently when serde+embed-descriptor are used together.
+      - run: cargo check --all-targets --no-default-features --features protoc,embed-descriptor,serde
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ include = [
 
 [features]
 default = []
+embed-descriptor = []
 extensions = ["dep:serde_yaml"]
 parse = ["dep:hex", "dep:thiserror", "semver"]
 protoc = ["dep:protobuf-src"]

--- a/build.rs
+++ b/build.rs
@@ -274,10 +274,9 @@ pub static EXTENSIONS: LazyLock<HashMap<Urn, SimpleExtensions>> = LazyLock::new(
 
 #[cfg(feature = "serde")]
 /// Serialize and deserialize implementations for proto types using `pbjson`
-fn serde(protos: &[impl AsRef<Path>], out_dir: PathBuf) -> Result<(), Box<dyn Error>> {
+fn serde(protos: &[impl AsRef<Path>], descriptor_path: PathBuf) -> Result<(), Box<dyn Error>> {
     use pbjson_build::Builder;
 
-    let descriptor_path = out_dir.join("proto_descriptor.bin");
     let mut cfg = Config::new();
     cfg.file_descriptor_set_path(&descriptor_path);
     cfg.compile_well_known_types()
@@ -327,11 +326,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         })
         .collect::<Vec<_>>();
 
+    let descriptor_path = out_dir.join("proto_descriptor.bin");
+
     #[cfg(feature = "serde")]
-    serde(&protos, out_dir)?;
+    serde(&protos, descriptor_path)?;
 
     #[cfg(not(feature = "serde"))]
-    Config::new().compile_protos(&protos, &[PROTO_ROOT])?;
+    Config::new()
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(&protos, &[PROTO_ROOT])?;
 
     Ok(())
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -24,6 +24,13 @@ include!(concat!(env!("OUT_DIR"), "/substrait.rs"));
 #[cfg(feature = "serde")]
 include!(concat!(env!("OUT_DIR"), "/substrait.serde.rs"));
 
+/// The encoded file descriptor set for the Substrait protobuf definitions.
+///
+/// This can be used for protobuf reflection.
+#[cfg(feature = "embed-descriptor")]
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/proto_descriptor.bin"));
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "serde")]
@@ -80,5 +87,16 @@ mod tests {
         );
         assert_eq!(plan.extension_urns.len(), 1);
         Ok(())
+    }
+
+    #[cfg(feature = "embed-descriptor")]
+    #[test]
+    fn file_descriptor_set_is_valid() {
+        use prost::Message;
+        let fds = prost_types::FileDescriptorSet::decode(super::FILE_DESCRIPTOR_SET).unwrap();
+        assert!(
+            fds.file.iter().any(|f| f.package() == "substrait"),
+            "expected substrait package in file descriptor set"
+        );
     }
 }


### PR DESCRIPTION
This can be used for reflection, and for build.rs of dependencies that depend on substrait protos.

See prost docs at https://github.com/tokio-rs/prost?tab=readme-ov-file#accessing-the-protoc-filedescriptorset