### PR TITLE
chore: render BREAKING CHANGE footers in the changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,44 @@
 [workspace]
 release_always = false
 
+# Extends release-plz's default changelog body with a "Breaking changes" section
+# that renders the `BREAKING CHANGE:` footer of each breaking commit. The default
+# template only emits the `[**breaking**]` marker and the summary line, which
+# drops the migration detail authors write in the footer.
+#
+# Everything up to the `has_breaking_desc` block is release-plz's default body.
+# A commit is only listed if its `breaking_description` differs from its summary:
+# for a `feat!:` commit with no footer git-cliff falls back to the summary, and
+# repeating it would be noise.
+[changelog]
+body = """
+## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+
+{% for commit in commits %}
+{%- if commit.scope -%}
+- *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
+{% else -%}
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+{% endif -%}
+{% endfor -%}
+{% endfor %}
+{%- set_global has_breaking_desc = false -%}
+{%- for commit in commits -%}
+{%- if commit.breaking and commit.breaking_description and commit.breaking_description != commit.message -%}
+{%- set_global has_breaking_desc = true -%}
+{%- endif -%}
+{%- endfor -%}
+{%- if has_breaking_desc %}
+### ⚠ Breaking changes
+{% for commit in commits %}{% if commit.breaking and commit.breaking_description and commit.breaking_description != commit.message %}
+**{{ commit.message }}**
+
+{{ commit.breaking_description }}
+{% endif %}{% endfor %}
+{%- endif %}"""
+
 [[package]]
 name = "substrait"
 publish_allow_dirty = true


### PR DESCRIPTION
## What

Extends release-plz's default changelog body with a `⚠ Breaking changes` section
that renders each breaking commit's `BREAKING CHANGE:` footer.

## Why

release-plz's default template emits only the `[**breaking**]` marker and the
commit summary, so the migration detail an author writes in the footer never
reaches [CHANGELOG.md](CHANGELOG.md).

v0.64.0 is a case in point. The footer of #507 enumerates every affected
`proto` / `text` / `parse` item, but the generated changelog entry is one line:

```
- [**breaking**] use packaged substrait-prost and substrait-extensions crates (#507)
```

A consumer hitting a compile error after upgrading has to find the commit to
learn what moved.

## How

`[changelog].body` in [release-plz.toml](release-plz.toml) starts as a verbatim
copy of release-plz's default body, then appends a section iterating
`commit.breaking_description`.

A commit is skipped when its `breaking_description` equals its summary. git-cliff
falls back to the summary for a `feat!:` commit with no footer, so this keeps
bang-only commits from being repeated, and a `set_global` pre-pass omits the
heading entirely when no commit in the release has a footer.

## Verification

Rendered the template *extracted from `release-plz.toml`* (so the TOML
round-trip is covered) with git-cliff 2.13.1:

| Case | Result |
| --- | --- |
| `v0.63.0..main` (the real v0.64.0 range) | full #507 footer rendered under the new heading |
| footer only, no `!` | rendered |
| `!` plus footer | rendered |
| `!` only, no footer | not repeated |
| no breaking commits | heading absent |
| scoped commits (`*(deps,github-actions)*`) | unchanged from default |

`npx prettier --check --no-config .` passes.

## Scope

[#512](https://github.com/substrait-io/substrait-rs/pull/512) merged first, so
v0.64.0 shipped with the one-line entry quoted above. This template applies from
v0.65.0 onward.

Merging this will open a fresh release PR, which doubles as the check that the
268 `cargo-semver-checks` false positives on #512 are gone now that the baseline
is 0.64.0 and both sides of the comparison re-export from `substrait-prost` /
`substrait-extensions`.

🤖 Generated with AI
