### PR TITLE
feat(deps,substrait)!: bump substrait from `0.87.0` to `0.102.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "substrait-extensions"
-version = "0.87.0"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73dfa39674c1af4b7951dc7a5c353c8be24593b395faac61ca82594a27b0cc44"
+checksum = "d33afcbcf85005f788199c2de7983caef24d858c6909391208f8aad2516db46d"
 dependencies = [
  "heck",
  "include_dir",
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "substrait-prost"
-version = "0.87.0"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aba90370eb71dc6e439c92f0e82c86afe44a42842b4d113a92693775a856f76"
+checksum = "ee6b74c488901400ff424a98b3505a105dd041de1aa9c355dad9f7f6115b4521"
 dependencies = [
  "pbjson",
  "pbjson-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,6 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ serde = ["substrait-prost/serde"]
 # Generated Substrait types, packaged from the spec. Pinned to an exact version
 # so the reported Substrait version (derived from this pin in build.rs) is
 # unambiguous. Both track the same spec tag and are bumped together.
-substrait-prost = "=0.87.0"
-substrait-extensions = "=0.87.0"
+substrait-prost = "=0.102.0"
+substrait-extensions = "=0.102.0"
 hex = { version = "0.4.3", optional = true }
 prost = "0.14.1"
 semver = { version = "1.0.27", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,11 @@ hex = { version = "0.4.3", optional = true }
 prost = "0.14.1"
 semver = { version = "1.0.27", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.145", features = ["preserve_order"] }
+# `preserve_order` is deliberately not enabled: it is a global feature, so
+# turning it on here would switch `serde_json::Map` to `indexmap::IndexMap`
+# for every crate in a downstream build with no way to opt out. Maps whose
+# order is significant use `indexmap` directly instead.
+serde_json = "1.0.145"
 serde_yaml = { version = "0.9.34", optional = true }
 thiserror = { version = "2.0.17", optional = true }
 indexmap = { version = "2.7.0", features = ["serde"] }

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ const SUBSTRAIT_DEP: &str = "substrait-prost";
 /// [`SUBSTRAIT_DEP`] dependency in this crate's `Cargo.toml`.
 ///
 /// The packaged Substrait crates are versioned to track the spec tag (e.g.
-/// `substrait-prost 0.87.0` corresponds to Substrait `v0.87.0`), and we
+/// `substrait-prost x.y.z` corresponds to Substrait `vx.y.z`), and we
 /// pin them to an exact version, so the requirement in `Cargo.toml` equals the
 /// resolved version. `Cargo.toml` is always present at `CARGO_MANIFEST_DIR`
 /// (including when this crate is consumed as a dependency), which makes this
@@ -28,9 +28,9 @@ fn substrait_version() -> Result<semver::Version, Box<dyn Error>> {
         .and_then(toml::Value::as_table)
         .and_then(|deps| deps.get(SUBSTRAIT_DEP))
         .and_then(|dep| match dep {
-            // `substrait-prost = "=0.87.0"`
+            // `substrait-prost = "=x.y.z"`
             toml::Value::String(version) => Some(version.as_str()),
-            // `substrait-prost = { version = "=0.87.0", ... }`
+            // `substrait-prost = { version = "=x.y.z", ... }`
             toml::Value::Table(table) => table.get("version").and_then(toml::Value::as_str),
             _ => None,
         })

--- a/src/parse/text/simple_extensions/registry.rs
+++ b/src/parse/text/simple_extensions/registry.rs
@@ -50,9 +50,6 @@ impl Registry {
     }
 
     /// Create a Global Registry from the built-in core extensions.
-    ///
-    /// Most core extensions are included. Some are skipped due to bugs in the upstream
-    /// YAML files (see <https://github.com/substrait-io/substrait/issues/935>).
     #[cfg(feature = "extensions")]
     pub fn from_core_extensions() -> Self {
         use crate::extensions::EXTENSIONS;
@@ -60,20 +57,11 @@ impl Registry {
         // Parse the core extensions from the raw extensions format to the parsed format
         let extensions: HashMap<Urn, SimpleExtensions> = EXTENSIONS
             .iter()
-            .filter_map(|(orig_urn, simple_extensions)| {
-                // Skip specific core extensions that have bugs (missing u! prefix on type references).
-                // Most core extensions are included; only these problematic ones are filtered out.
-                // See: https://github.com/substrait-io/substrait/issues/935
-                let urn_str = orig_urn.to_string();
-                if urn_str == "extension:io.substrait:extension_types" ||
-                   urn_str == "extension:io.substrait:unknown" {
-                    return None;
-                }
-
+            .map(|(orig_urn, simple_extensions)| {
                 let ExtensionFile { urn, extension } = ExtensionFile::create(simple_extensions.clone())
                     .unwrap_or_else(|err| panic!("Core extensions should be valid, but failed to create extension file for {orig_urn}: {err}"));
                 debug_assert_eq!(orig_urn, &urn);
-                Some((urn, extension))
+                (urn, extension)
             })
             .collect();
 
@@ -200,11 +188,12 @@ mod tests {
         let type_via_registry = registry.get_type(&urn, "geometry");
         assert!(type_via_registry.is_some());
 
-        // Verify extension_types is skipped due to u! prefix bug (substrait#935)
-        let extension_types_urn = Urn::from_str("extension:io.substrait:extension_types").unwrap();
+        // `unsigned_integers` was added to the catalog in Substrait v0.101.0.
+        let unsigned_integers_urn =
+            Urn::from_str("extension:io.substrait:unsigned_integers").unwrap();
         assert!(
-            registry.get_extension(&extension_types_urn).is_none(),
-            "extension_types should be skipped due to missing u! prefix bug"
+            registry.get_extension(&unsigned_integers_urn).is_some(),
+            "unsigned_integers should be a core extension"
         );
     }
 

--- a/src/parse/text/simple_extensions/type_ast.rs
+++ b/src/parse/text/simple_extensions/type_ast.rs
@@ -178,12 +178,12 @@ mod tests {
             ("i32", TypeExpr::Simple("i32", vec![], false)),
             ("i32?", TypeExpr::Simple("i32", vec![], true)),
             ("MAP", TypeExpr::Simple("MAP", vec![], false)),
-            ("timestamp", TypeExpr::Simple("timestamp", vec![], false)),
+            ("date", TypeExpr::Simple("date", vec![], false)),
             (
-                "timestamp_tz?",
-                TypeExpr::Simple("timestamp_tz", vec![], true),
+                "interval_year?",
+                TypeExpr::Simple("interval_year", vec![], true),
             ),
-            ("time", TypeExpr::Simple("time", vec![], false)),
+            ("uuid", TypeExpr::Simple("uuid", vec![], false)),
             ("any", TypeExpr::Simple("any", vec![], false)),
         ];
 

--- a/src/parse/text/simple_extensions/types.rs
+++ b/src/parse/text/simple_extensions/types.rs
@@ -88,14 +88,8 @@ pub enum BasicBuiltinType {
     String,
     /// Variable-length binary data - `binary`
     Binary,
-    /// Naive Timestamp
-    Timestamp,
-    /// Timestamp with time zone - `timestamp_tz`
-    TimestampTz,
     /// Calendar date - `date`
     Date,
-    /// Time of day - `time`
-    Time,
     /// Year-month interval - `interval_year`
     IntervalYear,
     /// 128-bit UUID - `uuid`
@@ -182,10 +176,7 @@ impl fmt::Display for BasicBuiltinType {
             BasicBuiltinType::Fp64 => f.write_str("fp64"),
             BasicBuiltinType::String => f.write_str("string"),
             BasicBuiltinType::Binary => f.write_str("binary"),
-            BasicBuiltinType::Timestamp => f.write_str("timestamp"),
-            BasicBuiltinType::TimestampTz => f.write_str("timestamp_tz"),
             BasicBuiltinType::Date => f.write_str("date"),
-            BasicBuiltinType::Time => f.write_str("time"),
             BasicBuiltinType::IntervalYear => f.write_str("interval_year"),
             BasicBuiltinType::Uuid => f.write_str("uuid"),
             BasicBuiltinType::FixedChar { length } => write!(f, "FIXEDCHAR<{length}>"),
@@ -243,10 +234,7 @@ fn primitive_builtin(lower_name: &str) -> Option<BasicBuiltinType> {
         "fp64" => Some(BasicBuiltinType::Fp64),
         "string" => Some(BasicBuiltinType::String),
         "binary" => Some(BasicBuiltinType::Binary),
-        "timestamp" => Some(BasicBuiltinType::Timestamp),
-        "timestamp_tz" => Some(BasicBuiltinType::TimestampTz),
         "date" => Some(BasicBuiltinType::Date),
-        "time" => Some(BasicBuiltinType::Time),
         "interval_year" => Some(BasicBuiltinType::IntervalYear),
         "uuid" => Some(BasicBuiltinType::Uuid),
         _ => None,
@@ -1196,9 +1184,6 @@ mod tests {
             ("uuid", Some(BasicBuiltinType::Uuid)),
             ("date", Some(BasicBuiltinType::Date)),
             ("interval_year", Some(BasicBuiltinType::IntervalYear)),
-            ("time", Some(BasicBuiltinType::Time)),
-            ("timestamp", Some(BasicBuiltinType::Timestamp)),
-            ("timestamp_tz", Some(BasicBuiltinType::TimestampTz)),
             ("invalid", None),
         ];
 

--- a/src/parse/text/simple_extensions/types.rs
+++ b/src/parse/text/simple_extensions/types.rs
@@ -18,7 +18,7 @@ use crate::text::simple_extensions::{
     TypeParamDefsItem, TypeParamDefsItemType,
 };
 use indexmap::IndexMap;
-use serde_json::{Map, Value};
+use serde_json::Value;
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::RangeInclusive;
@@ -884,14 +884,12 @@ impl fmt::Display for ConcreteType {
 impl From<ConcreteType> for RawType {
     fn from(val: ConcreteType) -> Self {
         match val.kind {
-            ConcreteTypeKind::NamedStruct { fields } => {
-                let map = Map::from_iter(
-                    fields
-                        .into_iter()
-                        .map(|(name, ty)| (name, serde_json::Value::String(ty.to_string()))),
-                );
-                RawType::Object(map)
-            }
+            ConcreteTypeKind::NamedStruct { fields } => RawType::Object(
+                fields
+                    .into_iter()
+                    .map(|(name, ty)| (name, serde_json::Value::String(ty.to_string())))
+                    .collect(),
+            ),
             _ => RawType::String(val.to_string()),
         }
     }
@@ -1175,13 +1173,12 @@ mod tests {
     /// Create a raw named struct (e.g. straight from YAML) from field name and
     /// type pairs
     fn raw_named_struct(fields: &[(&str, &str)]) -> RawType {
-        let map = Map::from_iter(
+        RawType::Object(
             fields
                 .iter()
-                .map(|(name, ty)| ((*name).into(), serde_json::Value::String((*ty).into()))),
-        );
-
-        RawType::Object(map)
+                .map(|(name, ty)| ((*name).into(), serde_json::Value::String((*ty).into())))
+                .collect(),
+        )
     }
 
     #[test]
@@ -1472,11 +1469,12 @@ mod tests {
     /// round-tripping through RawType (Substrait #915).
     #[test]
     fn test_named_struct_field_order_stability() -> Result<(), ExtensionTypeError> {
-        let mut raw_fields = Map::new();
-        raw_fields.insert("beta".to_string(), Value::String("i32".to_string()));
-        raw_fields.insert("alpha".to_string(), Value::String("string?".to_string()));
-
-        let raw = RawType::Object(raw_fields);
+        let raw = RawType::Object(
+            [("beta", "i32"), ("alpha", "string?")]
+                .into_iter()
+                .map(|(name, ty)| (name.to_string(), Value::String(ty.to_string())))
+                .collect(),
+        );
         let mut ctx = TypeContext::default();
         let concrete = Parse::parse(raw, &mut ctx)?;
 


### PR DESCRIPTION
Beyond raising the pin:

- `RawType::Object` payloads are built with `collect()` so the map type follows the generated variant, which `substrait-extensions` changed to `indexmap::IndexMap`.
- `serde_json`'s `preserve_order` feature is dropped. `substrait-extensions` 0.102.0 stopped enabling it too, so this crate was the last thing forcing it on every downstream build.
- `from_core_extensions` loses its skip list for `extension_types` and `unknown`: v0.99.0 and v0.101.0 removed `unknown`, `extension_types` and `type_variations` from the `extensions/` folder.
- `timestamp`, `timestamp_tz` and `time` no longer parse as builtin types, since v0.88.0 removed all three in favour of the `precision_*` types.
- The pin examples in `substrait_version` use `x.y.z` placeholders so they stop going stale on every bump.

BREAKING CHANGE: the Substrait version reported by `substrait::version` moves from `0.87.0` to `0.102.0`, so `parse` now accepts plans declaring Substrait `>=0.102.0, <0.103.0` and rejects the `0.87.x` range it accepted before.

BREAKING CHANGE: the generated `RawType::Object` payload changed from `serde_json::Map` to `indexmap::IndexMap`, which is observable to callers that construct or match on that variant.

BREAKING CHANGE: the `BasicBuiltinType::Timestamp`, `BasicBuiltinType::TimestampTz` and `BasicBuiltinType::Time` variants are removed, and `timestamp`, `timestamp_tz` and `time` no longer parse as builtin type names.

BREAKING CHANGE: `serde_json`'s `preserve_order` feature is no longer enabled by this crate. Builds that relied on `substrait` turning it on, whether for their own code or another dependency's, get `serde_json::Map` back as a sorted `BTreeMap` and have to enable the feature themselves.

Closes #502.
